### PR TITLE
Save seed value in EEPROM for every 5 mins

### DIFF
--- a/node/node.ino
+++ b/node/node.ino
@@ -3,21 +3,36 @@
 #include <ESP8266WebServer.h>
 #include <time.h>
 #include <Ticker.h>
+#include <EEPROM.h>
 
 Ticker blinker;
 
 const char* password = "";
 char ssid[100];
+unsigned int addr = 0;
 unsigned long long a, c, m, seed;
-void change_seed(){
-  seed = (seed%m) * (a%m);
-  seed = seed%m;
+
+void change_seed() {
+  seed = (seed % m) * (a % m);
+  seed = seed % m;
   seed += c;
   seed %= m;
 }
 
-void changeWifi(){
+void get_seed() {
+  EEPROM.get(addr, seed);
+  Serial.print("current seed changed in EEPROM");
+  if (seed == NULL){
+    seed = 1000;
+    EEPROM.put(addr, seed);
+    EEPROM.commit();
+  }
+}
+
+void changeWifi() {
   change_seed();
+  EEPROM.put(addr, seed);
+  EEPROM.commit();
   sprintf(ssid, "amFOSS_%d", seed);
   WiFi.softAP(ssid, password);
   Serial.println(ssid);
@@ -26,7 +41,9 @@ void changeWifi(){
 void setup() {
   delay(1000);
   Serial.begin(115200);
+  EEPROM.begin(512);
   Serial.print("Initial Setup");
+  get_seed();
   change_seed();
   sprintf(ssid, "amFOSS_%d", seed);
   WiFi.softAP(ssid, password);


### PR DESCRIPTION
Currently, when node turns off we loose the value of the seed and it will start from the beginning of series
so, by using EEPROM memory saved the value for every 5 mins so, when node turns off we can recover the past value